### PR TITLE
AnyCPU PlatformTarget for Release

### DIFF
--- a/src/NPOI.Extension.csproj
+++ b/src/NPOI.Extension.csproj
@@ -30,7 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">


### PR DESCRIPTION
Current version from NuGet might be used under x64 only. I've changed to AnyCPU.